### PR TITLE
Add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(name='351elec-webui',
       author='benphelps',
       author_email='bphelpsen@gmail.com',
       url='https://github.com/benphelps/351elec-webui',
-      license='MIT',
+      license='GPLv2+',
       platforms=['Linux'],
       install_requires=['ftfy']
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+from setuptools import setup
+setup(name='351elec-webui',
+      version='1.0',
+      description='Web Interface for 351ELEC',
+      author='benphelps',
+      author_email='bphelpsen@gmail.com',
+      url='https://github.com/benphelps/351elec-webui',
+      license='MIT',
+      platforms=['Linux'],
+      install_requires=['ftfy']
+
+      )


### PR DESCRIPTION
Will enable building as part of the 351ELEC build system in the future.

Feel free to just copy/paste/edit this and add yourself (I don't need to be credited for this 'contribution' - I just was trying to test a working build)

The only thing that matters to 351ELEC build system is that you put any dependencies in: `install_requires` (ftfy)