### PR TITLE
Fix laserdisc games not displaying due to being folders

### DIFF
--- a/assets/svgs/laserdisc.svg
+++ b/assets/svgs/laserdisc.svg
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg38"
+   sodipodi:docname="laserdisc.svg"
+   width="264"
+   height="55.000248"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata44">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs42" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview40"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="2.36"
+     inkscape:cx="50.847458"
+     inkscape:cy="2.8816046"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg38" />
+  <polygon
+     points="18.395,31.869 3.634,31.869 8.63,0 23.846,0 "
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="polygon2" />
+  <polygon
+     points="17.26,40.232 29.751,40.232 27.934,53.115 0,53.115 2.726,36.617 17.714,36.617 "
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="polygon4" />
+  <polygon
+     points="210.526,11.753 196.672,11.753 198.034,2.713 211.887,2.713 "
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="polygon6" />
+  <polygon
+     points="207.46,32.322 193.606,32.322 196.104,15.596 209.956,15.596 "
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="polygon8" />
+  <polygon
+     points="204.279,53.115 190.425,53.115 192.925,36.617 206.777,36.617 "
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="polygon10" />
+  <polygon
+     points="140.918,53.115 127.064,53.115 129.563,36.617 143.416,36.617 "
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="polygon12" />
+  <path
+     d="m 44.852,36.617 c -0.117,1.066 -0.197,2.424 -0.077,3.644 0.165,1.489 0.746,2.68 2.166,2.68 1.87,0 2.997,-1.637 3.643,-3.571 0.365,-1.007 0.626,-1.839 0.816,-2.788 l 12.909,-0.035 -2.63,16.614 H 50.202 l 0.674,-3.308 c -2.844,3.6 -5.121,4.468 -9.907,4.468 -9.14,0 -10.6,-10.092 -10.021,-17.701 z"
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="path14"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 51.975,32.322 c 0.011,-0.947 -0.002,-1.507 -0.047,-2.17 -0.134,-1.714 -0.673,-3.201 -2.392,-3.201 -1.795,0 -2.869,1.787 -3.621,3.946 -0.107,0.336 -0.201,0.66 -0.622,1.419 L 31.269,32.307 c 1.861,-7.956 6.051,-17.264 15.18,-17.451 2.492,-0.051 7.147,0.288 8.968,3.832 l 0.398,0.077 0.589,-3.203 h 11.248 l -2.591,16.76 z"
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="path16"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 68.473,32.322 c -0.838,-1.664 -1.188,-3.656 -0.855,-6.026 1.139,-8.114 7.267,-12.231 16.465,-12.231 3.963,0 6.718,0.927 9.886,2.86 l -1.508,10.419 c -2.3,-1.916 -6.466,-2.933 -8.934,-2.933 -1.047,0 -2.347,0.245 -2.667,1.482 -0.466,1.795 1.555,2.782 4.013,3.646 2.032,0.716 3.76,1.6 5.139,2.765 z"
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="path18"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 93.154,36.652 c 0.626,1.708 0.813,3.764 0.508,5.934 -1.245,8.856 -8.881,12.188 -17.031,12.188 -5.384,0 -7.649,-0.999 -11.931,-3.53 l 1.915,-11.658 c 1.458,1.86 6.399,4.827 9.706,4.658 1.269,-0.065 3.834,-0.935 4.032,-2.348 0.198,-1.413 -0.413,-2.455 -3.603,-3.465 -1.492,-0.471 -2.911,-0.97 -4.167,-1.741 z"
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="path20"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 108.317,36.623 c -0.552,3.323 -0.678,8.541 2.366,8.909 1.961,0.239 4.004,-1.344 4.624,-5.353 h 12.313 c -2.146,12.597 -9.563,14.883 -18.387,14.82 C 99.619,54.928 93.864,47.137 94.569,36.605 Z"
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="path22"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 237.542,32.319 c 1.806,-9.875 6.64,-17.942 20.461,-18.254 2.713,-0.062 4.869,0.852 5.997,1.505 l -1.787,10.692 c -5.485,-2.214 -8.468,2.132 -9.522,6.075 z"
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="path24"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 252.374,36.623 c 0.37,2.462 1.795,4.757 4.569,4.757 l 3.016,-0.228 -1.758,11.966 c -2.142,0.563 -4.185,0.902 -6.958,0.865 -10.551,-0.15 -14.876,-7.87 -14.263,-17.375 z"
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="path26"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 174.425,36.623 c -1.651,2.663 -3.303,4.625 -7.05,4.286 l 0.647,-4.298 -14.588,0.009 -2.638,16.495 h 14.762 c 12.215,0 20.602,-5.317 24.712,-16.53 z"
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="path28"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 168.572,32.331 2.892,-18.543 c 5.904,0 7.265,4.52 6.13,12.657 -0.283,2.034 -0.681,4.18 -1.213,5.918 l 15.36,0.018 c 0.556,-2.29 0.8,-4.831 1.07,-7.519 C 194.854,4.52 183.727,0 172.599,0 h -13.854 l -1.93,14.465 c -2.271,0.452 -7.835,1.131 -10.788,5.087 -0.568,0.564 -0.908,0.338 -0.795,-0.34 l 0.568,-3.616 h -13.058 l -2.498,16.726 h 13.854 c 0.566,-2.374 6.812,-5.877 10.673,-4.069 l -0.648,4.054 z"
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="path30"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 210.64,32.322 c -0.838,-1.664 -1.188,-3.656 -0.855,-6.026 1.14,-8.114 7.267,-12.231 16.465,-12.231 3.963,0 6.718,0.927 9.887,2.86 l -1.51,10.419 c -2.3,-1.916 -6.466,-2.933 -8.933,-2.933 -1.046,0 -2.347,0.245 -2.667,1.482 -0.465,1.795 1.555,2.782 4.013,3.646 2.032,0.716 3.76,1.6 5.138,2.765 z"
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="path32"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 235.32,36.652 c 0.626,1.708 0.812,3.764 0.509,5.934 -1.244,8.856 -8.881,12.188 -17.031,12.188 -5.386,0 -7.651,-0.999 -11.931,-3.53 l 1.914,-11.658 c 1.458,1.86 6.399,4.827 9.706,4.658 1.27,-0.065 3.834,-0.935 4.032,-2.348 0.2,-1.413 -0.412,-2.455 -3.601,-3.465 -1.493,-0.471 -2.912,-0.97 -4.168,-1.741 z"
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="path34"
+     inkscape:connector-curvature="0" />
+  <path
+     d="M 113.88,14.065 C 102.764,14.14 97.294,21.904 95.135,32.316 l 33.563,0.009 c 0.371,-4.831 0.196,-9.51 -1.271,-11.634 -2.559,-3.704 -5.927,-6.678 -13.547,-6.626 z m 0.216,8.721 c 2.618,0 3.043,2.829 2.815,4.987 h -6.805 c 0.207,-2.01 1.523,-4.987 3.99,-4.987 z"
+     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd"
+     id="path36"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/helpers.py
+++ b/helpers.py
@@ -22,19 +22,19 @@ def list_folders(path):
             dirs.append(entry.name)
     return dirs
 
-def list_files(path):
+def list_files_and_folders(path):
     files = []
     if folder_exists(path):
         for entry in os.scandir(path):
-            if not entry.name.startswith('.') and entry.is_file():
+            if not entry.name.startswith('.'):
                 files.append(entry.name)
     return files
 
-def list_files_with_extensions(path, extensions):
+def list_files_and_folders_with_extensions(path, extensions):
     files = []
     if folder_exists(path):
         for entry in os.scandir(path):
-            if not entry.name.startswith('.') and entry.is_file() and os.path.splitext(entry)[1] in extensions:
+            if not entry.name.startswith('.') and os.path.splitext(entry)[1] in extensions:
                 files.append(entry.name)
     return files
 
@@ -157,6 +157,9 @@ def getsize_fmt(path):
                 return f"{size:3.1f}{unit}b"
             size /= 1024.0
         return f"{size:.1f}Yib"
+
+    if os.path.isdir(path):
+        return ""
     else:
         return "0b"
 
@@ -278,7 +281,8 @@ def get_game_info(system, game_ref):
                 'gametime': find_int(ele, 'gametime'),
                 'size': getsize_fmt(rom_path),
                 'size_raw': file_get_size(rom_path),
-                'have_rom': os.path.isfile(rom_path),
+                'have_rom': os.path.exists(rom_path),
+                'can_download': os.path.isfile(rom_path),
                 'saves': find_saves(system, rom_filename),
                 'screenshots': find_screenshots(rom_filename)
             }
@@ -298,7 +302,7 @@ def get_game_info(system, game_ref):
             return game
 
     rom_path = os.path.join(system_folder_path, unescape(game_ref))
-    if os.path.isfile(rom_path):
+    if os.path.exists(rom_path):
         game = {
             'id': game_ref,
             'name': game_ref,
@@ -325,8 +329,9 @@ def get_game_info(system, game_ref):
             'playcount': False,
             'gametime': False,
             'size': getsize_fmt(rom_path),
-            'size_raw': os.path.getsize(rom_path),
+            'size_raw': file_get_size(rom_path),
             'have_rom': True,
+            'can_download': os.path.isfile(rom_path),
             'saves': find_saves(system, rom_path),
             'screenshots': find_screenshots(rom_path),
         }
@@ -351,7 +356,7 @@ def list_roms(system):
             rom_filename = remove_prefix(find(game, 'path'), './')
 
             # Hide any entries where files don't exist
-            if not os.path.isfile(os.path.join(get_system_path(system),rom_filename)):
+            if not os.path.exists(os.path.join(get_system_path(system),rom_filename)):
                 continue
 
             known_roms.append(rom_filename)
@@ -367,7 +372,7 @@ def list_roms(system):
                 'path': rom_filename,
             })
 
-    rom_files = list_files(get_system_path(system))
+    rom_files = list_files_and_folders(get_system_path(system))
     extensions = system_ele.find("extension").text.split(" ")
 
     for file in rom_files:

--- a/server.py
+++ b/server.py
@@ -24,7 +24,7 @@ def index():
             'name': find_normalized(system, 'name'),
             'manufacturer': find_image_path(system, 'manufacturer'),
             'path': find_normalized(system, 'path'),
-            'roms': len(list_files_with_extensions(system_folder_path, extensions))
+            'roms': len(list_files_and_folders_with_extensions(system_folder_path, extensions))
         })
 
     systems_sorted = sorted(systems, key=lambda k: (-k['roms'], k['fullname']))

--- a/views/game.tpl
+++ b/views/game.tpl
@@ -130,9 +130,11 @@
                                 </div>
                                 <div class="ml-4 flex-shrink-0">
                                     % if game["have_rom"]:
+                                        % if game["can_download"]:
                                         <a href="/rom/{{ system }}/{{ game["path"] }}" class="font-medium underline text-theme-600 hover:text-theme-500 dark:text-theme-200 dark:hover:text-theme-300">
                                             <i class="far fa-download"></i>
                                         </a>
+                                        % end
                                     % else:
                                         <span class="font-medium text-theme-600 dark:text-theme-200">
                                             Missing ROM


### PR DESCRIPTION
# Summary
Implementing full support for 'folder based' roms is a large amount of work.  This change should be thought of as 'fixing bugs related to folder based roms' (as opposed to 'full support of folder based roms')

Limitations of games which are folders:
- Size of folder will not be displayed
- Download link will not be allowed/displayed
- Upload will not be allowed (a folder must be selected for upload - this is technically not a change - just a statement of what's supported)

Editing of metadata, etc, should work as expected

# Images
- Added `laserdisc` logo