### PR TITLE
Fix unicode 'wrench' in tools text system name

### DIFF
--- a/views/_header.tpl
+++ b/views/_header.tpl
@@ -113,6 +113,9 @@
             width: 100%;
             height: 100%;
         }
+        body {
+            font-family: sans-serif, FontAwesome;
+        }
 
         :root {
             --scrollbar-track-dark: #475569; /* slate-600 */


### PR DESCRIPTION
# Summary
The 'tools' system from 351ELEC (es_systems.cfg) contains a unicode character for a 'wrench'.  In the web UI, the wrench is displayed as a 'missing glyph' (box).

**edit**: Thanks to @benphelps for simplifying my **way** more complex solution. The fix is just to use CSS to have anything in the body fallback to `FontAwesome` for missing glyphs.  The end result is the `wrench` in `tools` displays properly. 